### PR TITLE
Use static linking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ FLAGS             =    -Wall -Wextra -pipe
 CFLAGS            =    -std=gnu11
 CXXFLAGS          =    -std=gnu++17
 ASFLAGS           =
-LDFLAGS           =
+LDFLAGS           =    -static
 LINKS             =
 
 RELEASE_DEFINES   =    $(DEFINES) NDEBUG=1


### PR DESCRIPTION
Allows the exectuable to run without a libgcc and libstdc++ dll.